### PR TITLE
Update AdaptiveCover.py

### DIFF
--- a/mapper_xmean_cover/AdaptiveCover.py
+++ b/mapper_xmean_cover/AdaptiveCover.py
@@ -28,7 +28,7 @@ def bic_centroid(X, c, assignments, BIC=True):
         if i not in set_assignments:
             empty_clusters.append(i)
 
-    assignments = np.asarray(assignments, dtype=np.int)
+    assignments = np.asarray(assignments, dtype=np.int64)
     for i in range(k):
         if i in empty_clusters:
             continue


### PR DESCRIPTION
Updated for Numpy 1.24. Replaced np.int with np.int64 since np.int is deprecated and throws an error.